### PR TITLE
Change proxy server address to server (uses dockers same origin policy)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "eject": "react-scripts eject",
     "serve": "serve -s build/"
   },
-  "proxy": "http://172.31.0.3:3001/",
+  "proxy": "http://server:3001/",
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
package.json contains `"proxy":"http://server:3001"` where server is automagically turned into the docker container's ip address on the docker network